### PR TITLE
missing metadata MichelsonMap(). . .

### DIFF
--- a/deploy/deploy.ts
+++ b/deploy/deploy.ts
@@ -19,6 +19,7 @@ async function orig() {
     let factory_store = {
         'all_collections' : new MichelsonMap(),
         'owned_collections': new MichelsonMap(), 
+        'metadata': new MichelsonMap()
     }
 
     try {


### PR DESCRIPTION
'BigMapValidationError: [metadata] Value must be a MichelsonMap'